### PR TITLE
refactor: simplify `Page` and `RowGroup` parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,7 @@ fn list_playlists(path: &PathBuf) -> rekordcrate::Result<()> {
                 .flat_map(|row_group| {
                     row_group
                         .present_rows()
+                        .iter()
                         .map(|row| {
                             if let Row::PlaylistTreeNode(playlist_tree) = row {
                                 playlist_tree.clone()

--- a/tests/test_pdb_num_rows.rs
+++ b/tests/test_pdb_num_rows.rs
@@ -31,7 +31,7 @@ fn assert_pdb_row_count(page_type: PageType, expected_row_count: usize) {
     let actual_row_count: usize = pages
         .into_iter()
         .flat_map(|page| page.row_groups.into_iter())
-        .map(|row_group| row_group.present_rows().count())
+        .map(|row_group| row_group.present_rows().len())
         .sum();
     assert_eq!(
         actual_row_count, expected_row_count,


### PR DESCRIPTION
The primary change here made was that we don't do the complicated row backwards parsing and instead just do it in a forward fashion. I also removed the support for leveraging the space from partial rowgroups. Previously the code was able to leverage the space just before the first valid rowgroup offset for serialization. Instead we now always round up to the RowGroup which may also work better since we don't know if a serialized database is actually allowed to use that space. Reading in data from there still works, the offsets may be invalid, but since the validity is guarded by the `row_presence_flags`, it doesn't matter.